### PR TITLE
Remove line causing deprecation error.

### DIFF
--- a/Formula/constant_sandbox.rb
+++ b/Formula/constant_sandbox.rb
@@ -2,7 +2,6 @@ class ConstantSandbox < Formula
   desc "Tool for ruby codebases used to enforce boundaries and modularize Rails applications"
   homepage "https://github.com/trashhalo/constant_sandbox"
   version "0.1.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/trashhalo/constant_sandbox/releases/download/v0.1.0/stable_x86_64-apple-darwin_constant_sandbox.zip"

--- a/Formula/readcli.rb
+++ b/Formula/readcli.rb
@@ -3,7 +3,6 @@ class Readcli < Formula
   desc "Tool to that lets you read website content* on the command line"
   homepage "https://github.com/trashhalo/readcli"
   version "0.0.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/trashhalo/readcli/releases/download/v0.0.2/readcli_0.0.2_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
Remove `bottle :unneeded` from the formula files. This is causing an error when `brew install` is called.

Here is an example of a [PR](https://github.com/charmbracelet/homebrew-tap/pull/4/commits/c2ef9d84126f4d704a26504b7718c28fe08bfafc) resolving this issue. The other Formulas _might_ need this change too.

